### PR TITLE
Temporarily enable large hash values

### DIFF
--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -106,7 +106,7 @@ typedef unsigned long long int ExactCounterType;
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
 typedef unsigned long long int HashIntoType;
 //typedef BigHashType HashIntoType;
-const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
+const unsigned char KSIZE_MAX = 128;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)
 typedef unsigned char WordLength;

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,6 +99,7 @@ private:\
 
 namespace khmer
 {
+class HashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 

--- a/lib/khmer.hh
+++ b/lib/khmer.hh
@@ -99,13 +99,14 @@ private:\
 
 namespace khmer
 {
-class HashType;
+class BigHashType;
 // largest number we can count up to, exactly. (8 bytes)
 typedef unsigned long long int ExactCounterType;
 
 // largest number we're going to hash into. (8 bytes/64 bits/32 nt)
 typedef unsigned long long int HashIntoType;
-const unsigned char KSIZE_MAX = sizeof(HashIntoType)*4;
+//typedef BigHashType HashIntoType;
+const unsigned char KSIZE_MAX = 32;//sizeof(HashIntoType)*4;
 
 // largest size 'k' value for k-mer calculations.  (1 byte/255)
 typedef unsigned char WordLength;

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,7 +64,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    HashType h, r;
+    BigHashType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
@@ -80,7 +80,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
     _h = h.as_ull();
     _r = r.as_ull();
 
-    return uniqify_rc(h.as_ull(), r.as_ull());
+    return uniqify_rc(h, r).as_ull();
 }
 
 // _hash: return the maximum of the forward and reverse hash.

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -40,6 +40,7 @@ Contact: khmer-project@idyll.org
 #include <string.h>
 #include <algorithm>
 #include <string>
+#include <iostream>
 
 #include "MurmurHash3.h"
 #include "khmer.hh"
@@ -64,9 +65,14 @@ HashIntoType _hash(const char * kmer, const WordLength k,
     }
 
     HashIntoType h = 0, r = 0;
+    HashType hh;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
+
+    hh |= twobit_repr(kmer[0]);
+    HashIntoType xx(hh.as_ull());
+    std::cout << "h: " << h << " hh: " << xx <<std::endl;
 
     for (WordLength i = 1, j = k - 2; i < k; i++, j--) {
         h = h << 2;

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -64,15 +64,10 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 
-    HashIntoType h = 0, r = 0;
-    HashType hh;
+    HashType h, r;
 
     h |= twobit_repr(kmer[0]);
     r |= twobit_comp(kmer[k-1]);
-
-    hh |= twobit_repr(kmer[0]);
-    HashIntoType xx(hh.as_ull());
-    std::cout << "h: " << h << " hh: " << xx <<std::endl;
 
     for (WordLength i = 1, j = k - 2; i < k; i++, j--) {
         h = h << 2;
@@ -82,10 +77,10 @@ HashIntoType _hash(const char * kmer, const WordLength k,
         r |= twobit_comp(kmer[j]);
     }
 
-    _h = h;
-    _r = r;
+    _h = h.as_ull();
+    _r = r.as_ull();
 
-    return uniqify_rc(h, r);
+    return uniqify_rc(h.as_ull(), r.as_ull());
 }
 
 // _hash: return the maximum of the forward and reverse hash.

--- a/lib/kmer_hash.cc
+++ b/lib/kmer_hash.cc
@@ -60,7 +60,7 @@ HashIntoType _hash(const char * kmer, const WordLength k,
                    HashIntoType& _h, HashIntoType& _r)
 {
     // sizeof(HashIntoType) * 8 bits / 2 bits/base
-    if (!(k <= sizeof(HashIntoType)*4) || !(strlen(kmer) >= k)) {
+    if (strlen(kmer) < k) {
         throw khmer_exception("Supplied kmer string doesn't match the underlying k-size.");
     }
 

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -38,6 +38,8 @@ Contact: khmer-project@idyll.org
 #ifndef KMER_HASH_HH
 #define KMER_HASH_HH
 
+#include <array>
+#include <iostream>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -112,6 +114,71 @@ HashIntoType _hash_murmur(const std::string& kmer);
 HashIntoType _hash_murmur(const std::string& kmer,
                           HashIntoType& h, HashIntoType& r);
 HashIntoType _hash_murmur_forward(const std::string& kmer);
+
+
+class HashType
+{
+	std::array<unsigned char, 8> bytes { {0, 0, 0, 0, 0, 0, 0, 0 } };
+public:
+	HashType() : bytes{{0, 0, 0, 0, 0, 0, 0, 0 }} {};
+	HashType(std::array<unsigned char, 8> const& bytes_) : bytes(bytes_) {};
+
+	unsigned long long int as_ull() {
+		unsigned long long int x(0);
+		for (int i = 0; i < 8; i++) {
+			x += pow(256, 8 - i - 1) * bytes[i];
+		}
+		return x;
+	}
+
+	HashType operator>>(int shift) {
+		HashType shifted;
+		int next_(0);
+		for (int s = 0; s < shift; s++) {
+			int carry(0);
+			for (int i = 0; i < 8; i++){
+				next_ = (bytes[i] & 1) ? 0x80 : 0;
+				shifted.bytes[i] = carry | (bytes[i] >> 1);
+				carry = next_;
+			}
+		}
+		return shifted;
+	}
+
+	HashType operator<<(int shift) {
+		HashType shifted;
+		int next_(0);
+		for (int s = 0; s < shift; s++) {
+			int carry(0);
+			for (int i = 8 - 1; i >= 0; i--){
+				next_ = (bytes[i] & 128) ? 1 : 0;
+				shifted.bytes[i] = carry | ((bytes[i] << 1) & 255);
+				carry = next_;
+			}
+		}
+		return shifted;
+	}
+
+	HashType operator<<=(int rhs){
+		*this = *this << rhs;
+		return *this;
+	}
+
+	HashType operator>>=(int rhs){
+		*this = *this >> rhs;
+		return *this;
+	}
+
+	HashType operator|(int rhs) {
+		bytes[7] |= rhs;
+		return *this;
+	}
+
+	HashType operator|=(int rhs){
+		*this = *this | rhs;
+		return *this;
+	}
+};
 
 /**
  * \class Kmer

--- a/lib/kmer_hash.hh
+++ b/lib/kmer_hash.hh
@@ -132,13 +132,13 @@ public:
 	}
 
 	HashType operator>>(int shift) {
-		HashType shifted;
+		HashType shifted(bytes);
 		int next_(0);
 		for (int s = 0; s < shift; s++) {
 			int carry(0);
 			for (int i = 0; i < 8; i++){
-				next_ = (bytes[i] & 1) ? 0x80 : 0;
-				shifted.bytes[i] = carry | (bytes[i] >> 1);
+				next_ = (shifted.bytes[i] & 1) ? 0x80 : 0;
+				shifted.bytes[i] = carry | (shifted.bytes[i] >> 1);
 				carry = next_;
 			}
 		}
@@ -146,13 +146,13 @@ public:
 	}
 
 	HashType operator<<(int shift) {
-		HashType shifted;
+		HashType shifted(bytes);
 		int next_(0);
 		for (int s = 0; s < shift; s++) {
 			int carry(0);
 			for (int i = 8 - 1; i >= 0; i--){
-				next_ = (bytes[i] & 128) ? 1 : 0;
-				shifted.bytes[i] = carry | ((bytes[i] << 1) & 255);
+				next_ = (shifted.bytes[i] & 128) ? 1 : 0;
+				shifted.bytes[i] = carry | ((shifted.bytes[i] << 1) & 255);
 				carry = next_;
 			}
 		}

--- a/tests/test_countgraph.py
+++ b/tests/test_countgraph.py
@@ -1491,3 +1491,25 @@ def test_counting_load_bigcount():
         print(i, count_table.count('ATATATATAT'))
     count = count_table.get('ATATATATAT')
     assert count == 500
+
+
+def test_reverse_bighash():
+    hi = khmer._Countgraph(31, PRIMES_1m)
+    kmer = 'C' * 31
+    hashval = hi.hash('C' * 31)
+    assert hi.reverse_hash(hashval) == kmer
+
+    hi = khmer._Countgraph(33, PRIMES_1m)
+    kmer = 'C' * 33
+    hashval = hi.hash('C' * 33)
+    assert hi.reverse_hash(hashval) != kmer
+
+    hi = khmer._Countgraph(63, PRIMES_1m)
+    kmer = 'C' * 63
+    hashval = hi.hash('C' * 63)
+    assert hi.reverse_hash(hashval) != kmer
+
+    hi = khmer._Countgraph(127, PRIMES_1m)
+    kmer = 'C' * 127
+    hashval = hi.hash('C' * 127)
+    assert hi.reverse_hash(hashval) != kmer

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -56,6 +56,9 @@ def test_forward_hash():
     assert khmer.forward_hash('CCCC', 4) == 170
     assert khmer.forward_hash('GGGG', 4) == 170
 
+    h = 13607885392109549066
+    assert khmer.forward_hash('GGTTGACGGGGCTCAGGGGGCGGCTGACTCCG', 32) == h
+
 
 def test_get_file_writer_fail():
     somefile = utils.get_temp_filename("potato")


### PR DESCRIPTION
A few small edits that allowed me to use k > 32. I only did limited testing against the C++ API and none against Python, but `make test` works, so...

You may not want to merge this yet, just wanted to show that it's a small step whenever we do want to take the leap.
